### PR TITLE
Add 'iptables' tags for easier deactivation of those tasks

### DIFF
--- a/roles/bahmni-emr/tasks/main.yml
+++ b/roles/bahmni-emr/tasks/main.yml
@@ -112,16 +112,20 @@
 - name: Get matched IpTable rule
   shell: iptables -nL --line-numbers | grep OPENMRS  -m 1 | cut -c 1-2
   register: matchedRule
+  tags:	iptables
 
 - name: delete matching rule if exists
   shell: iptables -D INPUT {{ matchedRule.stdout }}
   when: matchedRule.stdout!=""
+  tags:	iptables
 
 - name: Allow openmrs port through firewall
   command: /sbin/iptables -I INPUT 1 -p tcp --dport  {{ openmrs_port }} -j ACCEPT -m comment --comment "OPENMRS"
+  tags:	iptables
 
 - name: save iptables
   command: service iptables save
+  tags:	iptables
 
 - name: Retrieve salt from users
   command: >

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -8,30 +8,38 @@
 - name: Get matched IpTable rule
   shell: iptables -nL --line-numbers | grep "WEB SERVER"  -m 1 | cut -c 1-2
   register: matchedRule
+  tags: iptables
 
 - name: delete matching rule if exists
   shell: iptables -D INPUT {{ matchedRule.stdout }}
   when: matchedRule.stdout!=""
+  tags:	iptables
 
 - name: Allow port 80 through firewall
   command: /sbin/iptables -I INPUT 1 -p tcp --dport  80 -j ACCEPT -m comment --comment "WEB SERVER"
+  tags:	iptables
 
 - name: save iptables
   command: service iptables save
+  tags:	iptables
 
 - name: Get matched IpTable rule
   shell: iptables -nL --line-numbers | grep https  -m 1 | cut -c 1-2
   register: matchedRule
+  tags:	iptables
 
 - name: delete matching rule if exists
   shell: iptables -D INPUT {{ matchedRule.stdout }}
   when: matchedRule.stdout!=""
+  tags:	iptables
 
 - name: Allow port 443 through firewall
   command: /sbin/iptables -I INPUT 1 -p tcp --dport  443 -j ACCEPT -m comment --comment "https"
+  tags:	iptables
 
 - name: save iptables
   command: service iptables save
+  tags:	iptables
 
 - name: create bahmni-certs directory
   file: path=/etc/bahmni-certs state=directory owner={{ bahmni_user }} group={{ bahmni_group }} mode=755

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -59,13 +59,17 @@
 - name: Get matched IpTable rule
   shell: iptables -nL --line-numbers | grep MYSQL  -m 1 | cut -c 1-2
   register: matchedRule
+  tags: iptables
 
 - name: delete matching rule if exists
   shell: iptables -D INPUT {{ matchedRule.stdout }}
   when: matchedRule.stdout!=""
+  tags: iptables
 
 - name: Allow mysql port through firewall
   command: /sbin/iptables -I INPUT 1 -p tcp --dport 3306 -j ACCEPT -m comment --comment "MYSQL"
+  tags: iptables
 
 - name: save iptables
   command: service iptables save
+  tags: iptables


### PR DESCRIPTION
The current playbooks can not be used to install Bahmni on a Docker container, because Docker does not use 'iptables' to manage its network security.
Therefore I have added some tags on tasks related to 'iptables' configuration, so one can disable those tasks.