### PR TITLE
Modify playbook to run on 'local' group rather than 'all'

### DIFF
--- a/all.yml
+++ b/all.yml
@@ -13,7 +13,7 @@
   roles:
     - { role: httpd-maintenance, maintenance_status: start , tags: always}
 
-- hosts: all
+- hosts: local
   sudo: yes
   roles:
     - { role: selinux, selinux_state: enforcing, selinux_policy: targeted, tags: selinux }


### PR DESCRIPTION
Remove the installation of some base components on 'all' servers. Rather use the existing 'local' group that includes all servers anyway (as it is a super group of all other server groups [local:children]).

This is because 'all' is an Ansible default group that contains all servers, including 'localhost'.
The problem of including 'localhost' comes when Bahmni is to be installed on a remote server, not on 'localhost': the Ansible installation will install some of the Bahmni required components on 'localhost' even when another hostname is set in the inventory file.
