### PR TITLE
[Performance] Replace copy task with synchronize

### DIFF
--- a/roles/implementation-config/tasks/implementation-config.yml
+++ b/roles/implementation-config/tasks/implementation-config.yml
@@ -1,16 +1,19 @@
 - name: remove /var/www/bahmni_config
   file: path=/var/www/bahmni_config state=absent
 
-- name: create /var/www/bahmni_config
-  file: path=/var/www/bahmni_config state=directory owner={{ bahmni_user }} group={{ bahmni_group }} mode=755
-
 - name: Copy implementation config to /var/www/bahmni_config
-  copy:
-    src=/etc/bahmni-installer/deployment-artifacts/{{ implementation_name }}_config/
-    dest=/var/www/bahmni_config
-    mode=755
-    owner={{ bahmni_user }}
-    group={{ bahmni_group }}
+  synchronize:
+    src: /etc/bahmni-installer/deployment-artifacts/{{ implementation_name }}_config/
+    dest: /var/www/bahmni_config
+    rsync_path: "sudo rsync"
+    compress: true
+    delete: yes
+    recursive: true
+    rsync_opts:
+      - "--exclude=.git"
+
+- name: Ensure directory and permissions for /var/www/bahmni_config
+  file: path=/var/www/bahmni_config state=directory owner={{ bahmni_user }} group={{ bahmni_group }} mode=755 recurse=yes
 
 - name: check if obscalculator exists
   stat: path=/var/www/bahmni_config/openmrs/obscalculator


### PR DESCRIPTION
On a typical implementation (5200rpm hard drive), and config, the copy of implementation config takes > 10 minutes. Ansible copy task is known to be slow for a large number of files. sync, on the other hand, makes this much faster.