### PR TITLE
Modify playbook to run on 'local' group rather than 'all'

### DIFF
--- a/all.yml
+++ b/all.yml
@@ -13,7 +13,7 @@
   roles:
     - { role: httpd-maintenance, maintenance_status: start , tags: always}
 
-- hosts: all
+- hosts: local
   sudo: yes
   roles:
     - { role: selinux, selinux_state: enforcing, selinux_policy: targeted, tags: selinux }


### PR DESCRIPTION
Run against 'local' group rather than 'all', which was including the localhost, thus failing when installed somewhere else than 'localhost'
	modified:   all.yml