### PR TITLE
Fix SSL download problem

### DIFF
--- a/roles/mysql-backup-tool/tasks/main.yml
+++ b/roles/mysql-backup-tool/tasks/main.yml
@@ -8,6 +8,7 @@
   yum:
     name=https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.5/binary/redhat/6/x86_64/percona-xtrabackup-24-2.4.5-1.el6.x86_64.rpm
     state=present
+    validate_certs=no
   when: installed_xtrabackup.stdout.find("percona-xtrabackup") == -1
   tags: install
 


### PR DESCRIPTION
Fix error "Failed to validate the SSL certificate for www.percona.com:443

![centos 34 244 141 93 konsole_00703 1](https://user-images.githubusercontent.com/1228418/43533424-10239746-95b5-11e8-8437-4f2c47b09766.png)


I guess this could be fixed installing suggested python modules, but I did not want to mess all the python installation up, that is why I just skip SSL validation. 