### PR TITLE
BAH-935|Removed check_mode while installing python-psycopg2

### DIFF
--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -11,7 +11,6 @@
 
 - name: Install python-psycopg2
   yum: name=python-psycopg2 state=present
-  check_mode: yes
 
 - name: Install postgresql
   yum: name="postgresql{{postgres_bin_version}}-server.x86_64" state=present


### PR DESCRIPTION
Removed the unnecessary check_mode statement on the python-psycopg2 installation task