### PR TITLE
BAH-1058 - Don't ignore error to Start PostgreSQL

### DIFF
--- a/roles/pgbackrest-restore/tasks/main.yml
+++ b/roles/pgbackrest-restore/tasks/main.yml
@@ -23,4 +23,4 @@
   systemd:
     name=postgresql-{{ postgres_version }}
     state=started
-  ignore_errors: true
+  ignore_errors: false


### PR DESCRIPTION
Error in restarting PostgreSQL means that the restore has created some issue so the errors should not be ignored.
So changed the ignore_errors: to false.