### PR TITLE
BAH-1260 | Fix | Update OpenELIS URI with feed URI for authentication

### DIFF
--- a/roles/bahmni-erp-connect/templates/erp-atomfeed.properties.j2
+++ b/roles/bahmni-erp-connect/templates/erp-atomfeed.properties.j2
@@ -39,7 +39,7 @@ saleable.feed.generator.uri=http://{{ host }}:{{ openmrs_port }}/openmrs/ws/atom
 openelis.user={{ openelis_username }}
 openelis.password={{ openelis_password }}
 openelis.saleorder.feed.generator.uri=http://{{ host }}:{{ bahmni_lab_port }}/openelis/ws/feed/patient/recent
-openelis.uri=http://{{ host }}:{{ bahmni_lab_port }}/openelis
+openelis.uri=http://{{ host }}:{{ bahmni_lab_port }}/openelis/ws/feed/patient/recent
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Bahmni ERP Connect failed to authenticate with OpenELIS because the URI gave a redirect instead of success response. So updated the URI with the feed URI.