### PR TITLE
[FIX] [CRITICAL] postgres96 NOT FOUND ERROR

### DIFF
--- a/group_vars/local
+++ b/group_vars/local
@@ -75,8 +75,8 @@ python_gdata_rpm_name: python-gdata-2.0.11-1.el6.noarch.rpm
 python_gdata_rpm_url: "{{bahmni_repo_url}}/{{python_gdata_rpm_name}}"
 python_gdata_rpm_location: "{{download_folder}}/{{ python_gdata_rpm_name}}"
 
-postgres_repo_rpm_name: pgdg-redhat-repo-42.0-23.noarch.rpm
-postgres_repo_download_url: https://yum.postgresql.org/common/redhat/rhel-7-x86_64/pgdg-redhat-repo-42.0-23.noarch.rpm
+postgres_repo_rpm_name: pgdg-redhat96-9.6-3.noarch.rpm
+postgres_repo_download_url: https://repo.nrg.wustl.edu/postgres/9.6/redhat/rhel-6-x86_64/pgdg-redhat96-9.6-3.noarch.rpm
 postgres_repo_rpm_location: "{{download_folder}}/{{ postgres_repo_rpm_name}}"
 postgres_version: 9.6
 postgres_bin_version: 96


### PR DESCRIPTION
This resolves Critical error of "postgres96 NOT FOUND" as the same is no longer available on official redhat repo.

This is a quick fix until Bahmni Team brings in Support for postgres10 and make changes to the core.

This should be pulled to enable the new installations to successfully complete deployment of FULL BAHMNI.

- Dr.Rahul Tagarya , MBBS