### PR TITLE
BAH-1527 | Fix Postgres installation from local artifacts.

### DIFF
--- a/roles/bahmni-erp/tasks/main.yml
+++ b/roles/bahmni-erp/tasks/main.yml
@@ -9,17 +9,6 @@
 - name: install nonblockingloghandler
   pip: name=nonblockingloghandler state=present
 
-- name: Check if postgres yum repo rpm is present
-  stat: path={{postgres_repo_rpm_location}}
-  register: postgresRepoRpm
-
-- name: Download postgres yum repo rpm if not present
-  command: "wget -q -O {{ postgres_repo_rpm_location }} {{postgres_repo_download_url}} creates={{ postgres_repo_rpm_location }}"
-  when: postgresRepoRpm.stat.exists == false
-
-- name: Install postgresql yum repository
-  yum: name={{postgres_repo_rpm_location}} state=present
-
 - name: Install python-psycopg2
   yum: name=python-psycopg2 state=present
 

--- a/roles/bahmni-lab/tasks/main.yml
+++ b/roles/bahmni-lab/tasks/main.yml
@@ -1,14 +1,3 @@
-- name: Check if postgres yum repo rpm is present
-  stat: path={{postgres_repo_rpm_location}}
-  register: postgresRepoRpm
-
-- name: Download postgres yum repo rpm if not present
-  command: "wget -q -O {{ postgres_repo_rpm_location }} {{postgres_repo_download_url}} creates={{ postgres_repo_rpm_location }}"
-  when: postgresRepoRpm.stat.exists == false
-
-- name: Install postgresql yum repository
-  yum: name={{postgres_repo_rpm_location}} state=present
-
 - name: Check if bahmni-lab rpm needs an update
   command: yum list installed bahmni-lab
   register: installed_bahmni_lab

--- a/roles/bahmni-odoo/tasks/main.yml
+++ b/roles/bahmni-odoo/tasks/main.yml
@@ -1,15 +1,3 @@
-
-- name: Check if postgres yum repo rpm is present
-  stat: path={{postgres_repo_rpm_location}}
-  register: postgresRepoRpm
-
-- name: Download postgres yum repo rpm if not present
-  command: "wget -q -O {{ postgres_repo_rpm_location }} {{postgres_repo_download_url}} creates={{ postgres_repo_rpm_location }}"
-  when: postgresRepoRpm.stat.exists == false
-
-- name: Install postgresql yum repository
-  yum: name={{postgres_repo_rpm_location}} state=present
-
 - name: Install curl
   become: yes
   yum: name=curl state=present

--- a/roles/pacs-integration/tasks/main.yml
+++ b/roles/pacs-integration/tasks/main.yml
@@ -1,14 +1,3 @@
-- name: Check if postgres yum repo rpm is present
-  stat: path={{postgres_repo_rpm_location}}
-  register: postgresRepoRpm
-
-- name: Download postgres yum repo rpm if not present
-  command: "wget -q -O {{ postgres_repo_rpm_location }} {{postgres_repo_download_url}} creates={{ postgres_repo_rpm_location }}"
-  when: postgresRepoRpm.stat.exists == false
-
-- name: Install postgresql yum repository
-  yum: name={{postgres_repo_rpm_location}} state=present
-
 - name: Check if pacs-integration rpm needs an update
   command: yum list installed pacs-integration
   register: installed_pacs_integration

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -1,5 +1,9 @@
 download_folder: /opt
-postgres_repo_rpm_name: pgdg-redhat-repo-42.0-23.noarch.rpm
-postgres_repo_rpm_mirror: https://yum.postgresql.org/common/redhat/rhel-7-x86_64
-postgres_repo_download_url: "{{postgres_repo_rpm_mirror}}/{{postgres_repo_rpm_name}}"
-postgres_repo_rpm_location: "{{download_folder}}/{{ postgres_repo_rpm_name}}"
+postgres_rpm_name: postgresql96-9.6.24-1PGDG.rhel7.x86_64.rpm
+postgres_server_rpm_name: postgresql96-server-9.6.24-1PGDG.rhel7.x86_64.rpm
+postgres_libs_rpm_name: postgresql96-libs-9.6.24-1PGDG.rhel7.x86_64.rpm
+postgres_contrib_rpm_name: postgresql96-contrib-9.6.24-1PGDG.rhel7.x86_64.rpm
+postgres_rpm_location: "{{download_folder}}/{{postgres_rpm_name}}"
+postgres_server_rpm_location: "{{download_folder}}/{{postgres_server_rpm_name}}"
+postgres_libs_rpm_location: "{{download_folder}}/{{postgres_libs_rpm_name}}"
+postgres_contrib_rpm_location: "{{download_folder}}/{{postgres_contrib_rpm_name}}"

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,22 +1,17 @@
-- name: Check if postgres yum repo rpm is present
-  stat: path={{postgres_repo_rpm_location}}
-  register: postgresRepoRpm
-
-- name: Download postgres yum repo rpm if not present
-  command: "wget -q -O {{ postgres_repo_rpm_location }} {{postgres_repo_download_url}} creates={{ postgres_repo_rpm_location }}"
-  when: postgresRepoRpm.stat.exists == false
-
-- name: Install postgresql yum repository
-  yum: name={{postgres_repo_rpm_location}} state=present
-
 - name: Install python-psycopg2
   command: yum -y install python-psycopg2
 
-- name: Install postgresql
-  yum: name="postgresql{{postgres_bin_version}}-server" state=present
+- name: Install postgresql libs
+  yum: name={{postgres_libs_rpm_location}} state=present
+
+- name: Install postgres
+  yum: name={{postgres_rpm_location}} state=present
+
+- name: Install postgresql server
+  yum: name={{postgres_server_rpm_location}} state=present
 
 - name: Install postgresql-contrib
-  yum: name="postgresql{{postgres_bin_version}}-contrib" state=present
+  yum: name={{postgres_contrib_rpm_location}} state=present
 
 - name: Initiate database
   command: /usr/pgsql-{{postgres_version}}/bin/postgresql{{postgres_bin_version}}-setup initdb creates=/var/lib/pgsql/{{postgres_version}}/data/postgresql.conf


### PR DESCRIPTION
- Removes the installation of pgdg-redhat repo RPM.
- Installs postgres server and required dependencies from local artifacts.

With this new installer, the below commands needs to be triggered.
```
cd /opt
wget https://repo.mybahmni.org/releases/postgresql96-9.6.24-1PGDG.rhel7.x86_64.rpm
wget https://repo.mybahmni.org/releases/postgresql96-server-9.6.24-1PGDG.rhel7.x86_64.rpm
wget https://repo.mybahmni.org/releases/postgresql96-libs-9.6.24-1PGDG.rhel7.x86_64.rpm
wget https://repo.mybahmni.org/releases/postgresql96-contrib-9.6.24-1PGDG.rhel7.x86_64.rpm
```
After this the installer can be fired as usual
`bahmni -i local install`