### PR TITLE
Revert "BAH-2131|Report-generated-on time-is-incorrect-in-report (#81)"

### DIFF
--- a/roles/bahmni-reports/templates/bahmni-reports.properties.j2
+++ b/roles/bahmni-reports/templates/bahmni-reports.properties.j2
@@ -51,4 +51,3 @@ bahmnireports.db.url=jdbc:mysql://{{ groups['bahmni-reports-db'][0] }}:3306/bahm
 {% endif %}
 
 reports.save.directory={{ reports_save_dir }}
-reports.timezone=


### PR DESCRIPTION
Jira -> https://bahmni.atlassian.net/browse/BAH-2131
Jira -> https://bahmni.atlassian.net/browse/BAH-3005

The timezone issue that was reported in [BAH-2131](https://bahmni.atlassian.net/browse/BAH-2131) was resolved when configuring the timezone as part of card [BAH-3005](https://bahmni.atlassian.net/browse/BAH-3005). The changes in https://github.com/Bahmni/bahmni-docker/pull/45 would take care of the incorrect time in the reports header. The timezone conversions made as part of [BAH-2131](https://bahmni.atlassian.net/browse/BAH-2131) are hence being reverted. This reverts commit 21ed9751347f7d2afd6966b2b23b1e32ade28499.